### PR TITLE
feat: add `waiting renderer` login state

### DIFF
--- a/etc/kernel-interface.api.md
+++ b/etc/kernel-interface.api.md
@@ -137,7 +137,9 @@ export enum LoginState {
     SIGNATURE_PENDING = "SIGNATURE_PENDING",
     // (undocumented)
     WAITING_PROFILE = "WAITING_PROFILE",
-    WAITING_PROVIDER = "WAITING_PROVIDER"
+    WAITING_PROVIDER = "WAITING_PROVIDER",
+    // (undocumented)
+    WAITING_RENDERER = "WAITING_RENDERER"
 }
 
 // @public (undocumented)

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ export enum LoginState {
    * Ready to authenticate
    */
   WAITING_PROVIDER = "WAITING_PROVIDER",
+  WAITING_RENDERER = "WAITING_RENDERER",
   /**
    * Authenticating
    */


### PR DESCRIPTION
Necessary for decentraland/unity-renderer#1235